### PR TITLE
Fix for multiple PartialWidgetPageAjax requests

### DIFF
--- a/PartialWidgetPage/PartialWidgetPageExtensions.cs
+++ b/PartialWidgetPage/PartialWidgetPageExtensions.cs
@@ -61,7 +61,7 @@ public static class PartialWidgetPageExtensions
         string DivID = Guid.NewGuid().ToString().Replace("-", "");
         string Content = $"<div id=\"Partial-{DivID}\"></div>" +
             $"<script type=\"text/javascript\">" +
-            $"(function() { var PartialContainer_{DivID} = document.getElementById('Partial-{DivID}'); " +
+            $"(function() {{ var PartialContainer_{DivID} = document.getElementById('Partial-{DivID}'); " +
             $"var RequestObj = (XMLHttpRequest) ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');" +
             $"RequestObj.open('GET', '{url}', true);" +
             $"RequestObj.send();" +
@@ -69,7 +69,7 @@ public static class PartialWidgetPageExtensions
             $"  if(RequestObj.readyState == 4) {{" +
             $"     PartialContainer_{DivID}.innerHTML = (RequestObj.status == 200) ? RequestObj.responseText : '<!-- Error retrieving page content at {url} -->';" +
             $"  }}" +
-            $"}};})();" +
+            $"}};}})();" +
             $"</script>";
         return new HtmlString(Content);
     }


### PR DESCRIPTION
The javascript request object was getting overwritten by each new request.  
I self contained each requests so that they no longer interfere with each other.