### PR TITLE
Update Local Cookie Domain/Port

### DIFF
--- a/PartialWidgetPage/CookieAwareClient.cs
+++ b/PartialWidgetPage/CookieAwareClient.cs
@@ -66,7 +66,7 @@ namespace PartialWidgetPage
 
                     if (!string.IsNullOrWhiteSpace(Domain))
                     {
-	                    cookieJar.Add(CurrentRequest.IsLocal ? new Cookie(CookieKey, Cookie.Value, Cookie.Path, Domain) { Port = $@"""{CurrentRequest.Url.Port}""" } : new Cookie(CookieKey, Cookie.Value, Cookie.Path, Domain));
+	                    cookieJar.Add(new Cookie(CookieKey, Cookie.Value, Cookie.Path, Domain) { Port = CurrentRequest.IsLocal ? $@"""{CurrentRequest.Url.Port}""" : "" });
                     }
                 }
             }

--- a/PartialWidgetPage/CookieAwareClient.cs
+++ b/PartialWidgetPage/CookieAwareClient.cs
@@ -66,7 +66,7 @@ namespace PartialWidgetPage
 
                     if (!string.IsNullOrWhiteSpace(Domain))
                     {
-	                    cookieJar.Add(new Cookie(CookieKey, Cookie.Value, Cookie.Path, Domain) { Port = CurrentRequest.IsLocal ? $@"""{CurrentRequest.Url.Port}""" : "" });
+						cookieJar.Add(new Cookie(CookieKey, Cookie.Value, Cookie.Path, Domain) { Port = CurrentRequest.IsLocal ? $@"""{CurrentRequest.Url.Port}""" : "" });
                     }
                 }
             }

--- a/PartialWidgetPage/CookieAwareClient.cs
+++ b/PartialWidgetPage/CookieAwareClient.cs
@@ -61,11 +61,12 @@ namespace PartialWidgetPage
                 {
                     var Cookie = CurrentRequest.Cookies[CookieKey];
 
-                    // CookieContainer requires a domain. so if it's empty, then use the Current Request's Host / Authority.
-                    string Domain = string.IsNullOrWhiteSpace(Cookie.Domain) ? (CurrentRequest.IsLocal ? CurrentRequest.Url.Authority : CurrentRequest.Url.Host) : Cookie.Domain;
+                    // CookieContainer requires a domain. so if it's empty, then use the Current Request's Host.
+                    string Domain = string.IsNullOrWhiteSpace(Cookie.Domain) ? CurrentRequest.Url.Host : Cookie.Domain;
+
                     if (!string.IsNullOrWhiteSpace(Domain))
                     {
-                        cookieJar.Add(new Cookie(CookieKey, Cookie.Value, Cookie.Path, Domain));
+	                    cookieJar.Add(CurrentRequest.IsLocal ? new Cookie(CookieKey, Cookie.Value, Cookie.Path, Domain) { Port = $@"""{CurrentRequest.Url.Port}""" } : new Cookie(CookieKey, Cookie.Value, Cookie.Path, Domain));
                     }
                 }
             }

--- a/PartialWidgetPage/PartialWidgetPageExtensions.cs
+++ b/PartialWidgetPage/PartialWidgetPageExtensions.cs
@@ -40,7 +40,7 @@ public static class PartialWidgetPageExtensions
     /// <returns>The rendered content</returns>
     public static HtmlString PartialWidgetPage(this HtmlHelper helper, string Path, string RenderAsPartialUrlParameter = null, bool PathIsNodeAliasPath = false, bool stripSession = true)
     {
-        using (CookieAwareWebClient client = new CookieAwareWebClient(HttpContext.Current.Request))
+        using (CookieAwareWebClient client = new CookieAwareWebClient(HttpContext.Current.Request, stripSession))
         {
             string url = GetRequestUrl(Path, RenderAsPartialUrlParameter, PathIsNodeAliasPath);
             try


### PR DESCRIPTION
Fixes issue #10. Updated how a Cookie is created locally, as it doesn't like the Port included in the domain. 

Instead I updated the cookie to include the port directly, according to the documentation here: https://docs.microsoft.com/en-us/dotnet/api/system.net.cookie.port?redirectedfrom=MSDN&view=netframework-4.6.1#remarks